### PR TITLE
Removed hostname from namespace and moved to the tags

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,9 +1,6 @@
 {
 	"ImportPath": "github.com/intelsdi-x/snap-plugin-collector-libvirt",
-	"GoVersion": "go1.5",
-	"Packages": [
-		"./..."
-	],
+	"GoVersion": "go1.5.1",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -15,33 +12,29 @@
 			"Rev": "c41fbb0640f67e4fa19a915141fcae36d9226460"
 		},
 		{
-			"ImportPath": "github.com/gopherjs/gopherjs/js",
-			"Rev": "9e79153c1c8dfa135136342df1ee0e8588f6d0d5"
-		},
-		{
 			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
-			"Comment": "v0.11.0-beta",
-			"Rev": "42d9567651258bba268d94701eb171458e459645"
+			"Comment": "v0.13.0-beta",
+			"Rev": "ed2e620679f19950c660b3c44ce5a2f8e67eae17"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/core",
-			"Comment": "v0.11.0-beta",
-			"Rev": "42d9567651258bba268d94701eb171458e459645"
+			"Comment": "v0.13.0-beta",
+			"Rev": "ed2e620679f19950c660b3c44ce5a2f8e67eae17"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
-			"Comment": "v0.11.0-beta",
-			"Rev": "42d9567651258bba268d94701eb171458e459645"
+			"Comment": "v0.13.0-beta",
+			"Rev": "ed2e620679f19950c660b3c44ce5a2f8e67eae17"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
-			"Comment": "v0.11.0-beta",
-			"Rev": "42d9567651258bba268d94701eb171458e459645"
+			"Comment": "v0.13.0-beta",
+			"Rev": "ed2e620679f19950c660b3c44ce5a2f8e67eae17"
 		},
 		{
 			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
-			"Comment": "v0.11.0-beta",
-			"Rev": "42d9567651258bba268d94701eb171458e459645"
+			"Comment": "v0.13.0-beta",
+			"Rev": "ed2e620679f19950c660b3c44ce5a2f8e67eae17"
 		},
 		{
 			"ImportPath": "github.com/jtolds/gls",
@@ -65,6 +58,10 @@
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
 			"Rev": "f7716cbe52baa25d2e9b0d0da546fcf909fc16b4"
+		},
+		{
+			"ImportPath": "github.com/gopherjs/gopherjs/js",
+			"Rev": "9e79153c1c8dfa135136342df1ee0e8588f6d0d5"
 		}
 	]
 }

--- a/example/snapd-config-sample.json
+++ b/example/snapd-config-sample.json
@@ -6,7 +6,7 @@
         "collector": {
             "libvirt": {
                 "versions": {
-                    "3": {
+                    "6": {
                     "uri": "qemu+tcp://10.1.0.75/system"
                         
                     }

--- a/example/task-example.json
+++ b/example/task-example.json
@@ -7,10 +7,10 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/libvirt/irild016.cslf1.intel.com/fedora22/cpu/cputime": {},
-                "/libvirt/irild016.cslf1.intel.com/fedora22/mem/available": {},
-                "/libvirt/irild016.cslf1.intel.com/fedora22/mem/rss": {},
-                "/libvirt/irild016.cslf1.intel.com/fedora22/mem/max": {}
+                "/libvirt/fedora22/cpu/cputime": {},
+                "/libvirt/fedora22/mem/available": {},
+                "/libvirt/fedora22/mem/rss": {},
+                "/libvirt/fedora22/mem/max": {}
             },
             "config": {
                 "/intel/dummy": {
@@ -21,12 +21,10 @@
             "process": [
                 {
                     "plugin_name": "passthru",
-                    "plugin_version": 1,
                     "process": null,
                     "publish": [
                         {
                             "plugin_name": "file",
-                            "plugin_version": 1,
                             "config": {
                                 "file": "/tmp/published"
                             }

--- a/libvirt/cpu.go
+++ b/libvirt/cpu.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -37,22 +37,22 @@ func cpuTimes(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, err
 		return nil, err
 	}
 	switch {
-	case regexp.MustCompile(`^/libvirt/.*/.*/cpu/cputime`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/cpu/cputime`).MatchString(joinNamespace(ns)):
 		cpuTime := info.GetCpuTime()
-		if ns[2] == "*" {
+		if ns[1] == "*" {
 			domainName, err := dom.GetName()
 			if err != nil {
 				return nil, err
 			}
-			ns[2] = domainName
+			ns[1] = domainName
 		}
 		return &plugin.PluginMetricType{
 			Namespace_: ns,
 			Data_:      cpuTime,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/cpu/vcpu/.*/cputime`).MatchString(joinNamespace(ns)):
-		nr, err := strconv.Atoi(ns[5])
+	case regexp.MustCompile(`^/libvirt/.*/cpu/vcpu/.*/cputime`).MatchString(joinNamespace(ns)):
+		nr, err := strconv.Atoi(ns[4])
 		if err != nil {
 			return nil, err
 		}
@@ -84,7 +84,7 @@ func getVcpuTime(nr int, info libvirt.VirDomainInfo, dom libvirt.VirDomain) uint
 
 }
 
-func getCPUMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.PluginMetricType, error) {
+func getCPUMetricTypes(dom libvirt.VirDomain) ([]plugin.PluginMetricType, error) {
 	var mts []plugin.PluginMetricType
 
 	domainname, err := dom.GetName()
@@ -101,10 +101,10 @@ func getCPUMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.PluginM
 
 		for i = 0; i < info.GetNrVirtCpu(); i++ {
 
-			mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", hostname, domainname, "cpu", "vcpu", strconv.FormatUint(uint64(i), 10), metric}})
+			mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", domainname, "cpu", "vcpu", strconv.FormatUint(uint64(i), 10), metric}})
 
 		}
-		mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", hostname, domainname, "cpu", metric}})
+		mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", domainname, "cpu", metric}})
 	}
 	return mts, nil
 }

--- a/libvirt/cpu_test.go
+++ b/libvirt/cpu_test.go
@@ -4,7 +4,7 @@
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,10 +32,9 @@ import (
 func TestLibirtPluginCpu(t *testing.T) {
 	Convey("Collect cpu Metrics", t, func() {
 		conn, _ := libvirt.NewVirConnection("test:///default")
-		hostname, _ := conn.GetHostname()
-		namespace := []string{"libvirt", hostname, "test", "cpu", "cputime"}
-		namespace2 := []string{"libvirt", hostname, "test", "cpu", "vcpu", "0", "cputime"}
-		namespace3 := []string{"libvirt", hostname, "test", "cpu", "0", "cputime", "bad"}
+		namespace := []string{"libvirt", "test", "cpu", "cputime"}
+		namespace2 := []string{"libvirt", "test", "cpu", "vcpu", "0", "cputime"}
+		namespace3 := []string{"libvirt", "test", "cpu", "0", "cputime", "bad"}
 		dom, err := conn.LookupDomainByName("test")
 		metric, err := cpuTimes(namespace, dom)
 		So(err, ShouldBeNil)
@@ -54,7 +53,7 @@ func TestLibirtPluginCpu(t *testing.T) {
 		Convey("Join namespace ", func() {
 			dom, _ := conn.LookupDomainByName(hostname)
 			So(dom, ShouldNotBeNil)
-			cpuTypes, err := getCPUMetricTypes(dom, "test")
+			cpuTypes, err := getCPUMetricTypes(dom)
 			So(err, ShouldBeNil)
 			So(3, ShouldResemble, len(cpuTypes))
 		})

--- a/libvirt/disk.go
+++ b/libvirt/disk.go
@@ -33,8 +33,8 @@ var diskMetricsTypes = []string{"wrreq", "rdreq", "wrbytes", "rdbytes"}
 
 func diskStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, error) {
 	switch {
-	case regexp.MustCompile(`^/libvirt/.*/.*/disk/.*/wrreq`).MatchString(joinNamespace(ns)):
-		disk := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/disk/.*/wrreq`).MatchString(joinNamespace(ns)):
+		disk := ns[3]
 		diskStat, err := dom.BlockStats(disk)
 		if err != nil {
 			return nil, err
@@ -44,8 +44,8 @@ func diskStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, err
 			Data_:      diskStat.WrReq,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/disk/.*/rdreq`).MatchString(joinNamespace(ns)):
-		disk := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/disk/.*/rdreq`).MatchString(joinNamespace(ns)):
+		disk := ns[3]
 		diskStat, err := dom.BlockStats(disk)
 		if err != nil {
 			return nil, err
@@ -56,7 +56,7 @@ func diskStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, err
 			Timestamp_: time.Now(),
 		}, nil
 	case regexp.MustCompile(`^/libvirt/.*/.*/disk/.*/wrbytes`).MatchString(joinNamespace(ns)):
-		disk := ns[4]
+		disk := ns[3]
 		diskStat, err := dom.BlockStats(disk)
 		if err != nil {
 			return nil, err
@@ -66,8 +66,8 @@ func diskStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, err
 			Data_:      diskStat.WrBytes,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/disk/.*/rdbytes`).MatchString(joinNamespace(ns)):
-		disk := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/disk/.*/rdbytes`).MatchString(joinNamespace(ns)):
+		disk := ns[3]
 		diskStat, err := dom.BlockStats(disk)
 		if err != nil {
 			return nil, err
@@ -93,7 +93,7 @@ func listDisks(domXML *etree.Document) []string {
 	return disks
 }
 
-func getDiskMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.PluginMetricType, error) {
+func getDiskMetricTypes(dom libvirt.VirDomain) ([]plugin.PluginMetricType, error) {
 	var mts []plugin.PluginMetricType
 	domXMLDesc, err := dom.GetXMLDesc(0)
 	if err != nil {
@@ -111,7 +111,7 @@ func getDiskMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.Plugin
 	for _, metric := range diskMetricsTypes {
 
 		for _, disk := range listDisks(domXML) {
-			mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", hostname, domainname, "disk", disk, metric}})
+			mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", domainname, "disk", disk, metric}})
 
 		}
 	}

--- a/libvirt/disk_test.go
+++ b/libvirt/disk_test.go
@@ -4,7 +4,7 @@
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/libvirt/libvirt_test.go
+++ b/libvirt/libvirt_test.go
@@ -4,7 +4,7 @@
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import (
 	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
 	"github.com/intelsdi-x/snap/core/cdata"
 	"github.com/intelsdi-x/snap/core/ctypes"
-	"github.com/sandlbn/libvirt-go"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -72,7 +71,7 @@ func TestLibirtPlugin(t *testing.T) {
 
 	})
 	Convey("Get Domain from Namespace ", t, func() {
-		namespace1 := []string{"libvirt", "skynet1", "t1000", "mem", "mem"}
+		namespace1 := []string{"libvirt", "t1000", "mem", "mem"}
 		namespace2 := []string{"libvirt"}
 		Convey("So should return t1000", func() {
 			domain, err := namespacetoDomain(namespace1)
@@ -114,72 +113,72 @@ func TestLibirtPlugin(t *testing.T) {
 		Convey("So should check namespace", func() {
 			metrics, err := libvirtCol.GetMetricTypes(cfg)
 			vcpuNamespace := joinNamespace(metrics[0].Namespace())
-			vcpu := regexp.MustCompile(`^/libvirt/.*/test/cpu/vcpu/0/cputime`)
+			vcpu := regexp.MustCompile(`^/libvirt/test/cpu/vcpu/0/cputime`)
 			So(true, ShouldEqual, vcpu.MatchString(vcpuNamespace))
 			So(err, ShouldBeNil)
 
 			vcpuNamespace1 := joinNamespace(metrics[1].Namespace())
-			vcpu1 := regexp.MustCompile(`^/libvirt/.*/test/cpu/vcpu/1/cputime`)
+			vcpu1 := regexp.MustCompile(`^/libvirt/test/cpu/vcpu/1/cputime`)
 			So(true, ShouldEqual, vcpu1.MatchString(vcpuNamespace1))
 			So(err, ShouldBeNil)
 
 			cpuNamespace := joinNamespace(metrics[2].Namespace())
-			cpu := regexp.MustCompile(`^/libvirt/.*/test/cpu/cputime`)
+			cpu := regexp.MustCompile(`^/libvirt/test/cpu/cputime`)
 			So(true, ShouldEqual, cpu.MatchString(cpuNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace := joinNamespace(metrics[3].Namespace())
-			mem := regexp.MustCompile(`^/libvirt/.*/test/mem/mem`)
+			mem := regexp.MustCompile(`^/libvirt/test/mem/mem`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[4].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/max`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/max`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[5].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/swap_in`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/swap_in`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[6].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/swap_out`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/swap_out`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[7].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/major_fault`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/major_fault`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[8].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/min_fault`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/min_fault`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[9].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/unused`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/unused`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[10].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/available`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/available`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[11].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/actual_balloon`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/actual_balloon`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[12].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/rss`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/rss`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 
 			memNamespace = joinNamespace(metrics[13].Namespace())
-			mem = regexp.MustCompile(`^/libvirt/.*/test/mem/nr`)
+			mem = regexp.MustCompile(`^/libvirt/test/mem/nr`)
 			So(true, ShouldEqual, mem.MatchString(memNamespace))
 			So(err, ShouldBeNil)
 		})
@@ -189,11 +188,9 @@ func TestLibirtPlugin(t *testing.T) {
 		libvirtCol := &Libvirt{}
 		cfgNode := cdata.NewNode()
 		cfgNode.AddItem("uri", ctypes.ConfigValueStr{Value: "test:///default"})
-		conn, _ := libvirt.NewVirConnection("test:///default")
-		hostname, _ := conn.GetHostname()
 		Convey("So should get cpu metrics", func() {
 			metrics := []plugin.PluginMetricType{{
-				Namespace_: []string{"libvirt", hostname, "test", "cpu", "vcpu", "0", "cputime"},
+				Namespace_: []string{"libvirt", "test", "cpu", "vcpu", "0", "cputime"},
 				Config_:    cfgNode,
 			}}
 			collect, err := libvirtCol.CollectMetrics(metrics)
@@ -203,7 +200,7 @@ func TestLibirtPlugin(t *testing.T) {
 		})
 		Convey("So should get vcpu metrics", func() {
 			metrics := []plugin.PluginMetricType{{
-				Namespace_: []string{"libvirt", hostname, "test", "cpu", "cputime"},
+				Namespace_: []string{"libvirt", "test", "cpu", "cputime"},
 				Config_:    cfgNode,
 			}}
 			collect, err := libvirtCol.CollectMetrics(metrics)

--- a/libvirt/mem.go
+++ b/libvirt/mem.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -36,30 +36,30 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 	if err != nil {
 		return nil, err
 	}
-	if ns[2] == "*" {
+	if ns[1] == "*" {
 		domainName, err := dom.GetName()
 		if err != nil {
 			return nil, err
 		}
-		ns[2] = domainName
+		ns[1] = domainName
 	}
 
 	switch {
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/mem`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/mem`).MatchString(joinNamespace(ns)):
 		memory := info.GetMemory()
 		return &plugin.PluginMetricType{
 			Namespace_: ns,
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/max`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/max`).MatchString(joinNamespace(ns)):
 		memory := info.GetMaxMem()
 		return &plugin.PluginMetricType{
 			Namespace_: ns,
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/swap_in`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/swap_in`).MatchString(joinNamespace(ns)):
 		swapIn, err := getMemoryInfo("swap_in", dom)
 		if err != nil {
 			return nil, err
@@ -70,7 +70,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/swap_out`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/swap_out`).MatchString(joinNamespace(ns)):
 		swapOut, err := getMemoryInfo("swap_out", dom)
 		if err != nil {
 			return nil, err
@@ -81,7 +81,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/min_fault`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/min_fault`).MatchString(joinNamespace(ns)):
 		minFault, err := getMemoryInfo("min_fault", dom)
 		if err != nil {
 			return nil, err
@@ -92,7 +92,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/major_fault`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/major_fault`).MatchString(joinNamespace(ns)):
 		majorFault, err := getMemoryInfo("major_fault", dom)
 		if err != nil {
 			return nil, err
@@ -103,7 +103,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/unused`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/unused`).MatchString(joinNamespace(ns)):
 		unused, err := getMemoryInfo("unused", dom)
 		if err != nil {
 			return nil, err
@@ -114,7 +114,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/available`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/available`).MatchString(joinNamespace(ns)):
 		available, err := getMemoryInfo("available", dom)
 		if err != nil {
 			return nil, err
@@ -125,7 +125,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/actual_balloon`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/actual_balloon`).MatchString(joinNamespace(ns)):
 		actualBalloon, err := getMemoryInfo("actual_balloon", dom)
 		if err != nil {
 			return nil, err
@@ -136,7 +136,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/rss`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/rss`).MatchString(joinNamespace(ns)):
 		rss, err := getMemoryInfo("rss", dom)
 		if err != nil {
 			return nil, err
@@ -147,7 +147,7 @@ func memStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, erro
 			Data_:      memory,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/mem/nr`).MatchString(joinNamespace(ns)):
+	case regexp.MustCompile(`^/libvirt/.*/mem/nr`).MatchString(joinNamespace(ns)):
 		nr, err := getMemoryInfo("nr", dom)
 		if err != nil {
 			return nil, err
@@ -203,7 +203,7 @@ func parseMemStats(memstat []libvirt.VirDomainMemoryStat, nr int32) uint64 {
 	return metric
 
 }
-func getMemMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.PluginMetricType, error) {
+func getMemMetricTypes(dom libvirt.VirDomain) ([]plugin.PluginMetricType, error) {
 	var mts []plugin.PluginMetricType
 
 	domainname, err := dom.GetName()
@@ -213,7 +213,7 @@ func getMemMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.PluginM
 
 	for _, metric := range memoryMetricsTypes {
 
-		mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", hostname, domainname, "mem", metric}})
+		mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", domainname, "mem", metric}})
 	}
 	return mts, nil
 }

--- a/libvirt/net.go
+++ b/libvirt/net.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ var netMetricsTypes = []string{"rxbytes", "rxpackets", "rxerrs", "rxdrop",
 
 func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType, error) {
 	switch {
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/rxbytes`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/rxbytes`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			return nil, err
@@ -45,8 +45,8 @@ func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType
 			Data_:      ifaceStat.RxBytes,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/rxpackets`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/rxpackets`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			return nil, err
@@ -56,8 +56,8 @@ func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType
 			Data_:      ifaceStat.RxPackets,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/rxerrs`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/rxerrs`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			return nil, err
@@ -67,8 +67,8 @@ func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType
 			Data_:      ifaceStat.RxErrs,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/rxdrop`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/rxdrop`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			return nil, err
@@ -78,8 +78,8 @@ func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType
 			Data_:      ifaceStat.RxDrop,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/txbytes`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/txbytes`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			return nil, err
@@ -89,8 +89,8 @@ func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType
 			Data_:      ifaceStat.TxBytes,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/txpackets`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/txpackets`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			return nil, err
@@ -100,8 +100,8 @@ func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType
 			Data_:      ifaceStat.TxPackets,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/txerrs`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/txerrs`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			fmt.Println(err)
@@ -111,8 +111,8 @@ func interfaceStat(ns []string, dom libvirt.VirDomain) (*plugin.PluginMetricType
 			Data_:      ifaceStat.TxErrs,
 			Timestamp_: time.Now(),
 		}, nil
-	case regexp.MustCompile(`^/libvirt/.*/.*/net/.*/txdrop`).MatchString(joinNamespace(ns)):
-		iface := ns[4]
+	case regexp.MustCompile(`^/libvirt/.*/net/.*/txdrop`).MatchString(joinNamespace(ns)):
+		iface := ns[3]
 		ifaceStat, err := dom.InterfaceStats(iface)
 		if err != nil {
 			return nil, err
@@ -137,7 +137,7 @@ func listInterfaces(domXML *etree.Document) []string {
 	return networkInterfaces
 }
 
-func getNetMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.PluginMetricType, error) {
+func getNetMetricTypes(dom libvirt.VirDomain) ([]plugin.PluginMetricType, error) {
 	var mts []plugin.PluginMetricType
 	domXMLDesc, err := dom.GetXMLDesc(0)
 	if err != nil {
@@ -154,7 +154,7 @@ func getNetMetricTypes(dom libvirt.VirDomain, hostname string) ([]plugin.PluginM
 	for _, metric := range netMetricsTypes {
 
 		for _, netInteface := range listInterfaces(domXML) {
-			mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", hostname, domainname, "net", netInteface, metric}})
+			mts = append(mts, plugin.PluginMetricType{Namespace_: []string{"libvirt", domainname, "net", netInteface, metric}})
 
 		}
 	}

--- a/libvirt/net_test.go
+++ b/libvirt/net_test.go
@@ -4,7 +4,7 @@
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
-Copyright 2015 Intel Corporation
+Copyright 2015-2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
After implementation of dynamic metric in snap framework is not possible to use dots in the namespace. I removed unnecessary hostname from namespace and moved it to the tags section. 