### PR TITLE
Fix for issue #23

### DIFF
--- a/libvirt/libvirt_test.go
+++ b/libvirt/libvirt_test.go
@@ -211,6 +211,24 @@ func TestLibirtPlugin(t *testing.T) {
 			So(collect[0].Data_, ShouldHaveSameTypeAs, expectedType)
 			So(len(collect), ShouldResemble, 1)
 		})
+		Convey("So should return only one metric", func() {
+			metrics := []plugin.MetricType{
+				{
+					Namespace_: core.NewNamespace("libvirt", "test", "cpu", "cputime"),
+					Config_:    cfgNode,
+				},
+				{
+					Namespace_: core.NewNamespace("libvirt", "*", "cpu", "cputime"),
+					Config_:    cfgNode,
+				},
+			}
+			collect, err := libvirtCol.CollectMetrics(metrics)
+			So(err, ShouldBeNil)
+			So(collect[0].Data_, ShouldNotBeNil)
+			var expectedType uint64
+			So(collect[0].Data_, ShouldHaveSameTypeAs, expectedType)
+			So(len(collect), ShouldResemble, 1)
+		})
 
 	})
 }

--- a/libvirt/mem.go
+++ b/libvirt/mem.go
@@ -196,7 +196,6 @@ func parseMemStats(memstat []libvirt.VirDomainMemoryStat, nr int32) uint64 {
 
 	var metric uint64
 	for i := 0; i < len(memstat); i++ {
-		fmt.Println(i, memstat[i].Tag, memstat[i].Val)
 		if memstat[i].Tag == nr {
 			return memstat[i].Val
 		}


### PR DESCRIPTION
Fixed issue #23 and https://github.com/intelsdi-x/snap/issues/963.
Unit test added. 

Tested on Ubuntu 14.04/CentOS 7 

Watching Task (5ab6ab6a-3a29-4d33-a8ef-d1035d240ac3):
NAMESPACE 					 DATA 		 TIMESTAMP 					 SOURCE
/libvirt/generic/cpu/cputime 			 8.3211e+11 	 2016-06-03 08:01:06.65495512 +0100 IST
/libvirt/generic/mem/actual_balloon 		 1.048576e+06 	 2016-06-03 08:01:06.599892379 +0100 IST
/libvirt/generic/mem/available 			 0 		 2016-06-03 08:01:06.617050183 +0100 IST
/libvirt/generic/mem/major_fault 		 0 		 2016-06-03 08:01:06.656969508 +0100 IST
/libvirt/generic/mem/max 			 1.048576e+06 	 2016-06-03 08:01:06.661713117 +0100 IST
/libvirt/generic/mem/mem 			 1.048576e+06 	 2016-06-03 08:01:06.627472388 +0100 IST
/libvirt/generic/mem/min_fault 			 0 		 2016-06-03 08:01:06.630950328 +0100 IST
/libvirt/generic/mem/nr 			 0 		 2016-06-03 08:01:06.664370106 +0100 IST
/libvirt/generic/mem/rss 			 54668 		 2016-06-03 08:01:06.638282855 +0100 IST
/libvirt/generic/mem/swap_in 			 0 		 2016-06-03 08:01:06.644676558 +0100 IST
/libvirt/generic/mem/swap_out 			 0 		 2016-06-03 08:01:06.670701372 +0100 IST
/libvirt/generic/mem/unused 			 0 		 2016-06-03 08:01:06.64946393 +0100 IST
/libvirt/ubuntu_mesos/cpu/cputime 		 1.0678e+11 	 2016-06-03 08:01:06.655232572 +0100 IST
/libvirt/ubuntu_mesos/mem/actual_balloon 	 524288 	 2016-06-03 08:01:06.603605893 +0100 IST
/libvirt/ubuntu_mesos/mem/available 		 0 		 2016-06-03 08:01:06.619129649 +0100 IST
/libvirt/ubuntu_mesos/mem/major_fault 		 0 		 2016-06-03 08:01:06.657836141 +0100 IST
/libvirt/ubuntu_mesos/mem/max 			 524288 	 2016-06-03 08:01:06.661975844 +0100 IST
/libvirt/ubuntu_mesos/mem/mem 			 524288 	 2016-06-03 08:01:06.627834325 +0100 IST
/libvirt/ubuntu_mesos/mem/min_fault 		 0 		 2016-06-03 08:01:06.633225665 +0100 IST
/libvirt/ubuntu_mesos/mem/nr 			 0 		 2016-06-03 08:01:06.665358787 +0100 IST
/libvirt/ubuntu_mesos/mem/rss 			 327932 	 2016-06-03 08:01:06.639286314 +0100 IST
/libvirt/ubuntu_mesos/mem/swap_in 		 0 		 2016-06-03 08:01:06.645481178 +0100 IST
/libvirt/ubuntu_mesos/mem/swap_out 		 0 		 2016-06-03 08:01:06.671547486 +0100 IST
/libvirt/ubuntu_mesos/mem/unused 		 0 		 2016-06-03 08:01:06.650381736 +0100 IST
/libvirt/vagrant_operator/cpu/cputime 		 3.5709e+11 	 2016-06-03 08:01:06.655464751 +0100 IST
/libvirt/vagrant_operator/mem/actual_balloon 	 4.194304e+06 	 2016-06-03 08:01:06.606592007 +0100 IST
/libvirt/vagrant_operator/mem/available 	 0 		 2016-06-03 08:01:06.621172374 +0100 IST
/libvirt/vagrant_operator/mem/major_fault 	 0 		 2016-06-03 08:01:06.658731247 +0100 IST
/libvirt/vagrant_operator/mem/max 		 4.194304e+06 	 2016-06-03 08:01:06.66232719 +0100 IST
/libvirt/vagrant_operator/mem/mem 		 4.194304e+06 	 2016-06-03 08:01:06.628233805 +0100 IST
/libvirt/vagrant_operator/mem/min_fault 	 0 		 2016-06-03 08:01:06.634225765 +0100 IST
/libvirt/vagrant_operator/mem/nr 		 0 		 2016-06-03 08:01:06.666414122 +0100 IST
/libvirt/vagrant_operator/mem/rss 		 808548 	 2016-06-03 08:01:06.640369413 +0100 IST
/libvirt/vagrant_operator/mem/swap_in 		 0 		 2016-06-03 08:01:06.646281044 +0100 IST
/libvirt/vagrant_operator/mem/swap_out 		 0 		 2016-06-03 08:01:06.672448333 +0100 IST
/libvirt/vagrant_operator/mem/unused 		 0 		 2016-06-03 08:01:06.651341868 +0100 IST