### PR TITLE
Fix for domain memory stats #38

### DIFF
--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -115,7 +115,7 @@ func GetVCPUStatistics(domain libvirt.VirDomain) (map[string]int64, error) {
 //GetMemoryStatistics returns Libvirt memory statistics
 func GetMemoryStatistics(domain libvirt.VirDomain, tags ...string) (map[string]int64, error) {
 	retValue := make(map[string]int64)
-	info, err := domain.MemoryStats(5, 0)
+	info, err := domain.MemoryStats(9, 0)
 	if err != nil {
 		return retValue, err
 	}

--- a/libvirtcollector/libvirtcollector.go
+++ b/libvirtcollector/libvirtcollector.go
@@ -33,7 +33,7 @@ const (
 	// Plugin plugin name
 	Plugin = "libvirt"
 	// Version of plugin
-	Version            = 11
+	Version            = 12
 	nsDomainPosition   = 2
 	nsMetricPostion    = 3
 	nsDevicePosition   = 4


### PR DESCRIPTION
Fixes #38

Summary of changes:
- Fixed memory stat for libvirt domain 

Testing done:
- Ubuntu 16.04 , CentOS 7 

