### PR TITLE
Increasing test coverage

### DIFF
--- a/example/tasks/task-example.yaml
+++ b/example/tasks/task-example.yaml
@@ -31,9 +31,9 @@
          /intel/libvirt/*/network/*/txbytes: {}
          /intel/libvirt/*/network/*/txdrop: {}
          /intel/libvirt/*/network/*/txerrs: {}
-         /intel/libvirt/*/network/*/txpackets: {}
-      publish:
-        - plugin_name: "file"
-          config:
+         /intel/libvirt/*/network/*/txpackets: {}          
+         /intel/libvirt/*/network/*/txpackets: {}          
+         publish:
+            plugin_name: "file"
+         config:
             file: "/tmp/libvirt_metrics.log"
-          

--- a/libvirt/libvirt_test.go
+++ b/libvirt/libvirt_test.go
@@ -1,14 +1,10 @@
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
-
 Copyright 2016 Intel Corporation
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
 	http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +16,7 @@ package libvirt
 
 import (
 	"encoding/xml"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -27,24 +24,47 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestLibirt(t *testing.T) {
-	Convey("Get Interface Name when Interface don't exist", t, func() {
+func TestLibvirtFundaments(t *testing.T) {
+	Convey("Connect to default libvirt", t, func() {
 		conn, err := libvirt.NewVirConnection("test:///default")
-		So(err, ShouldBeNil)
+		defer conn.CloseConnection()
+		Convey("connections should success", func() {
+			So(err, ShouldBeNil)
+		})
+
 		domains, err := GetInstances(conn)
-		So(err, ShouldBeNil)
-		So(len(domains), ShouldResemble, 1)
+		Convey("domain should be available", func() {
+			So(err, ShouldBeNil)
+			Convey("and be the only one", func() {
+				So(len(domains), ShouldResemble, 1)
+			})
+		})
 		interf, err := GetDomainInterfaces(domains[0])
-		So(err, ShouldNotBeNil)
-		So(len(interf), ShouldResemble, 0)
+		Convey("no interface", func() {
+			Convey("should be error", func() {
+				So(err, ShouldNotBeNil)
+			})
+			Convey("number of interfaces should be zero", func() {
+				So(len(interf), ShouldResemble, 0)
+			})
+
+		})
+		name, err := domains[0].GetName()
+		Convey("Its name should be test", func() {
+			So(name, ShouldEqual, "test")
+			Convey("Error should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+		id, err := domains[0].GetID()
+		Convey("and its ID should be 1", func() {
+			So(id, ShouldEqual, 1)
+			Convey("Error should be nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
 	})
-	Convey("Get DomainNames", t, func() {
-		conn, err := libvirt.NewVirConnection("test:///default")
-		So(err, ShouldBeNil)
-		domains, err := GetInstanceIds(conn)
-		So(err, ShouldBeNil)
-		So(len(domains), ShouldResemble, 1)
-	})
+
 	Convey("Get Interface Name when Interface exist", t, func() {
 		buf, err := ioutil.ReadFile("./test_domain.xml")
 		if err != nil {
@@ -65,18 +85,9 @@ func TestLibirt(t *testing.T) {
 		xml.Unmarshal([]byte(domXMLStr), &lXML)
 		So(len(lXML.Devices.Interface), ShouldResemble, 3)
 	})
-	Convey("Get Disk Name when disk don't exist", t, func() {
-		conn, err := libvirt.NewVirConnection("test:///default")
-		So(err, ShouldBeNil)
-		domains, err := GetInstances(conn)
-		So(err, ShouldBeNil)
-		So(len(domains), ShouldResemble, 1)
-		disk, err := GetDomainDisks(domains[0])
-		So(err, ShouldBeNil)
-		So(len(disk), ShouldResemble, 0)
-	})
 	Convey("Get Cpu Statistics", t, func() {
 		conn, err := libvirt.NewVirConnection("test:///default")
+		defer conn.CloseConnection()
 		So(err, ShouldBeNil)
 		domains, err := GetInstances(conn)
 		So(err, ShouldBeNil)
@@ -87,6 +98,7 @@ func TestLibirt(t *testing.T) {
 	})
 	Convey("Get vCpu Statistics", t, func() {
 		conn, err := libvirt.NewVirConnection("test:///default")
+		defer conn.CloseConnection()
 		So(err, ShouldBeNil)
 		domains, err := GetInstances(conn)
 		So(err, ShouldBeNil)
@@ -96,12 +108,82 @@ func TestLibirt(t *testing.T) {
 		expectedType := make(map[string]int64)
 		So(cpu, ShouldHaveSameTypeAs, expectedType)
 	})
+	Convey("Get Network Statistics without network interface neither path", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		defer conn.CloseConnection()
+		So(err, ShouldBeNil)
+		domains, err := GetInstances(conn)
+		network, err := GetNetworkStatistics(domains[0])
+		So(err, ShouldNotBeNil)
+		emptyMap := make(map[string]libvirt.VirDomainInterfaceStats)
+		So(network, ShouldResemble, emptyMap)
+	})
+	Convey("Get Network Statistics with one path", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		So(err, ShouldBeNil)
+		_, err = conn.DomainCreateXMLFromFile("./test_domain_multiple_interfaces.xml", 0)
+		So(err, ShouldBeNil)
+		defer conn.CloseConnection()
+		name := "instance-00000031"
+		domain, err := GetInstanceByDomainName(conn, name)
+		So(err, ShouldBeNil)
+		network, err := GetNetworkStatistics(domain, "tap88709cbd-90")
+		So(network["tap88709cbd-90"].RxBytes, ShouldNotBeNil)
+		So(network["tap88709cbd-90"].RxPackets, ShouldNotBeNil)
+		So(network["tap88709cbd-90"].RxDrop, ShouldNotBeNil)
+		So(network["tap88709cbd-90"].RxErrs, ShouldNotBeNil)
+		So(network["tap88709cbd-90"].TxBytes, ShouldNotBeNil)
+		So(network["tap88709cbd-90"].TxDrop, ShouldNotBeNil)
+		So(network["tap88709cbd-90"].TxErrs, ShouldNotBeNil)
+		So(network["tap88709cbd-90"].TxPackets, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		emptyMap := make(map[string]libvirt.VirDomainInterfaceStats)
+		So(network, ShouldHaveSameTypeAs, emptyMap)
+		So(network, ShouldNotBeEmpty)
+	})
+	Convey("Get Network Statistics with error", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		defer conn.CloseConnection()
+		conn.DomainCreateXMLFromFile("./test_domain_multiple_interfaces.xml", 0)
+		So(err, ShouldBeNil)
+		domains, err := GetInstances(conn)
+		block, err := GetNetworkStatistics(domains[0], "wrong")
+		emptyMap := make(map[string]libvirt.VirDomainInterfaceStats)
+		So(block, ShouldResemble, emptyMap)
+		So(err, ShouldNotBeNil)
+	})
+	Convey("Get Block Statistics", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		conn.DomainCreateXMLFromFile("test_domain.xml", 0)
+		defer conn.CloseConnection()
+		So(err, ShouldBeNil)
+		name := "instance-00000031"
+		domain, err := GetInstanceByDomainName(conn, name)
+		block, err := GetBlockStatistics(domain)
+		So(err, ShouldBeNil)
+		emptyMap := make(map[string]libvirt.VirDomainBlockStats)
+		So(block, ShouldHaveSameTypeAs, emptyMap)
+	})
+	Convey("Get Block Statistics with error", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		defer conn.CloseConnection()
+		conn.DomainCreateXMLFromFile("./test_domain_multiple_interfaces.xml", 0)
+		So(err, ShouldBeNil)
+		name := "instance-00000031"
+		domain, err := GetInstanceByDomainName(conn, name)
+		So(err, ShouldBeNil)
+		block, err := GetBlockStatistics(domain, "wrong")
+		emptyMap := make(map[string]libvirt.VirDomainBlockStats)
+		So(block, ShouldResemble, emptyMap)
+		So(err, ShouldNotBeNil)
+	})
 	Convey("Get Memory Statistics on Test Driver", t, func() {
 		conn, err := libvirt.NewVirConnection("test:///default")
+		defer conn.CloseConnection()
 		So(err, ShouldBeNil)
 		domains, err := GetInstances(conn)
 		So(err, ShouldBeNil)
-		So(len(domains), ShouldResemble, 1)
+		So(len(domains), ShouldResemble, 2)
 		cpu, err := GetMemoryStatistics(domains[0], "swap_in", "free")
 		So(err.Error(), ShouldContainSubstring, "this function is not supported by the connection driver: virDomainMemoryStats")
 		emptyMap := make(map[string]int64)
@@ -128,7 +210,7 @@ func TestLibirt(t *testing.T) {
 		So(lXML.GetNovaVcpus(), ShouldResemble, "1")
 
 	})
-	Convey("Get Nova Metadata when Metadata entity dosn't exist ", t, func() {
+	Convey("Get Nova Metadata when Metadata entity doesn't exist ", t, func() {
 		buf, err := ioutil.ReadFile("./test_domain.1.xml")
 		if err != nil {
 			panic(err)
@@ -155,5 +237,98 @@ func TestLibirt(t *testing.T) {
 		domains, err := GetRequestedInstances(conn, instances)
 		So(err, ShouldNotBeNil)
 		So(len(domains), ShouldResemble, 0)
+	})
+}
+
+func TestLibvirt(t *testing.T) {
+	Convey("Get Interface Name", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		conn.DomainCreateXMLFromFile("test_domain.xml", 0)
+		defer conn.CloseConnection()
+		So(err, ShouldBeNil)
+		name := "instance-00000031"
+		domain, err := GetInstanceByDomainName(conn, name)
+		So(err, ShouldBeNil)
+		interf, err := GetDomainInterfaces(domain)
+		So(err, ShouldBeNil)
+		So(len(interf), ShouldBeGreaterThan, 0)
+	})
+	Convey("Get Disk Name when disk don't exist", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		conn.DomainCreateXMLFromFile("test_domain.xml", 0)
+		defer conn.CloseConnection()
+		So(err, ShouldBeNil)
+		name := "instance-00000031"
+		domain, err := GetInstanceByDomainName(conn, name)
+		disk, err := GetDomainDisks(domain)
+		So(err, ShouldBeNil)
+		So(len(disk), ShouldResemble, 1)
+	})
+	Convey("Get Nova Metadata info", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		conn.DomainCreateXMLFromFile("test_domain.xml", 0)
+		defer conn.CloseConnection()
+		So(err, ShouldBeNil)
+		name := "instance-00000031"
+		domain, err := GetInstanceByDomainName(conn, name)
+		metadata, err := GetNovaMetadata(domain)
+		So(err, ShouldBeNil)
+		emptyMap := make(map[string]string)
+		So(metadata, ShouldHaveSameTypeAs, emptyMap)
+		So(len(metadata), ShouldResemble, 10)
+		So(metadata["nova_memory_mb"], ShouldEqual, "2048")
+		So(metadata["nova_owner"], ShouldEqual, "3aff4d1bd3b74afb8262411eaae47d7c")
+		So(metadata["nova_uuid"], ShouldEqual, "5a26891c-efb0-4c6a-8bef-b54c45296136")
+		So(metadata["nova_flavor"], ShouldEqual, "m1.small")
+		So(metadata["nova_ephemeral_mb"], ShouldEqual, "0")
+		So(metadata["nova_disk_mb"], ShouldEqual, "20")
+		So(metadata["nova_swap_mb"], ShouldEqual, "0")
+		So(metadata["nova_vcpus"], ShouldEqual, "1")
+		So(metadata["nova_name"], ShouldEqual, "demo_gui")
+		So(metadata["nova_package"], ShouldEqual, "2015.1.1")
+	})
+	Convey("ParseMemStats", t, func() {
+		Array := make([]libvirt.VirDomainMemoryStat, 3)
+		Array[0].Tag = 77
+		Array[0].Val = 7
+		Array[1].Tag = 33
+		Array[1].Val = 3
+		Array[2].Tag = 55
+		Array[2].Val = 5
+
+		var nr int32 = 33
+		number := parseMemStats(Array, nr)
+		var n int64 = 3
+		So(number, ShouldEqual, n)
+		So(number, ShouldHaveSameTypeAs, n)
+	})
+	Convey("ParseMemStats with empty array", t, func() {
+		emptyArray := make([]libvirt.VirDomainMemoryStat, 0)
+		var nr int32 = 33
+		number := parseMemStats(emptyArray, nr)
+		var n int64 = 0
+		So(number, ShouldEqual, n)
+		So(number, ShouldHaveSameTypeAs, n)
+	})
+	Convey("Get instances ID", t, func() {
+		conn, err := libvirt.NewVirConnection("test:///default")
+		defer conn.CloseConnection()
+		So(err, ShouldBeNil)
+		ids, err := GetInstanceIds(conn)
+		fmt.Println(ids)
+		fmt.Println(len(ids))
+		So(err, ShouldBeNil)
+		mockedIds := []string{"test", "instance-00000031"}
+		emptyArray := make([]string, 0)
+		So(ids, ShouldHaveSameTypeAs, emptyArray)
+		So(ids[0], ShouldBeIn, mockedIds)
+		So(ids[1], ShouldBeIn, mockedIds)
+		So(ids[0], ShouldNotEqual, ids[1])
+	})
+	Convey("Get instances ID with error", t, func() {
+		conn := libvirt.VirConnection{}
+		ids, err := GetInstanceIds(conn)
+		So(err, ShouldNotBeNil)
+		So(ids, ShouldBeNil)
 	})
 }

--- a/libvirt/test_domain_multiple_interfaces.xml
+++ b/libvirt/test_domain_multiple_interfaces.xml
@@ -1,4 +1,4 @@
-<domain type='kvm' id='34'>
+<domain type='test' id='34'>
   <name>instance-00000031</name>
   <uuid>5a26891c-efb0-4c6a-8bef-b54c45296136</uuid>
   <metadata>
@@ -39,7 +39,7 @@
     </system>
   </sysinfo>
   <os>
-    <type arch='x86_64' machine='pc-i440fx-utopic'>hvm</type>
+    <type arch='i686' machine='pc-i440fx-utopic'>hvm</type>
     <boot dev='hd'/>
     <smbios mode='sysinfo'/>
   </os>

--- a/libvirt/test_wo_disk.xml
+++ b/libvirt/test_wo_disk.xml
@@ -1,5 +1,5 @@
 <domain type='test' id='34'>
-  <name>instance-00000031</name>
+  <name>instance-00000032</name>
   <uuid>5a26891c-efb0-4c6a-8bef-b54c45296136</uuid>
   <metadata>
     <nova:instance xmlns:nova="http://openstack.org/xmlns/libvirt/nova/1.0">
@@ -8,7 +8,6 @@
       <nova:creationTime>2015-11-05 13:15:50</nova:creationTime>
       <nova:flavor name="m1.small">
         <nova:memory>2048</nova:memory>
-        <nova:disk>20</nova:disk>
         <nova:swap>0</nova:swap>
         <nova:ephemeral>0</nova:ephemeral>
         <nova:vcpus>1</nova:vcpus>
@@ -61,18 +60,6 @@
   <on_crash>destroy</on_crash>
   <devices>
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
-    <disk type='file' device='disk'>
-      <driver name='qemu' type='qcow2' cache='none'/>
-      <source file='/var/lib/nova/instances/5a26891c-efb0-4c6a-8bef-b54c45296136/disk'/>
-      <backingStore type='file' index='1'>
-        <format type='raw'/>
-        <source file='/var/lib/nova/instances/_base/ec273646b7327f7e13f4b7afa1c8c0fa3c4d0cc2'/>
-        <backingStore/>
-      </backingStore>
-      <target dev='vda' bus='virtio'/>
-      <alias name='virtio-disk0'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
-    </disk>
     <controller type='usb' index='0'>
       <alias name='usb0'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>

--- a/libvirtcollector/libvirtcollector.go
+++ b/libvirtcollector/libvirtcollector.go
@@ -33,7 +33,7 @@ const (
 	// Plugin plugin name
 	Plugin = "libvirt"
 	// Version of plugin
-	Version            = 14
+	Version            = 15
 	nsDomainPosition   = 2
 	nsMetricPostion    = 3
 	nsDevicePosition   = 4


### PR DESCRIPTION
Fixes #

Summary of changes (added tests):
- Get Network Statistics without network interface neither path
- Get Network Statistics with one path
- Get Network Statistics with error
- Get Block Statistics
- Get Block Statistics with error
- Get Interface Name
- Get Disk Name when disk don't exist
- Get Nova Metadata info
- ParseMemStats
- ParseMemStats with empty array
- Get instances ID
- Get instances ID with error
- added test_wo_disk.xml

How to verify it:
- read/run tests
