### PR TITLE
fix diskcounter query timeout issue

### DIFF
--- a/libvirtcollector/libvirtcollector.go
+++ b/libvirtcollector/libvirtcollector.go
@@ -143,6 +143,14 @@ func (LibvirtCollector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, er
 			}
 
 		}
+
+		if diskCount > 0 {
+			diskCounters, err = wrapper.GetBlockStatistics(id)
+			if err != nil {
+				return metrics, err
+			}
+		}
+
 		for _, mt := range diskMetrics {
 			ns := copyNamespace(mt)
 			if ns[nsDomainPosition].IsDynamic() {
@@ -151,12 +159,7 @@ func (LibvirtCollector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, er
 					return metrics, err
 				}
 			}
-			if diskCount > 0 {
-				diskCounters, err = wrapper.GetBlockStatistics(id)
-				if err != nil {
-					return metrics, err
-				}
-			}
+
 			for k, v := range diskCounters {
 				newNamespace := copyNamespaceElements(ns)
 				if newNamespace[nsDevicePosition].IsDynamic() {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #
In customer environment, "diskCounters, err = wrapper.GetBlockStatistics(id)" is repeated invoking so many times on each id. And GetBlockStatistics(id) spends almost 1 second on some of VMs on our Env, so the total time will over time. 

Summary of changes:
- Move getDiskcounter out of cycles

How to verify it:
-

Testing done:
- Compile and simple libvirt environment testing finished. 

A picture of a snapping turtle (not required but encouraged):
-
